### PR TITLE
Add basic login page with cookie authentication

### DIFF
--- a/TestCodex/Pages/Account/Login.cshtml
+++ b/TestCodex/Pages/Account/Login.cshtml
@@ -1,0 +1,29 @@
+@page
+@model TestCodex.Pages.Account.LoginModel
+@{
+    Layout = "_Layout";
+}
+
+<h2>Login</h2>
+
+<form method="post">
+    <div class="form-group">
+        <label asp-for="Input.UserName"></label>
+        <input asp-for="Input.UserName" class="form-control" />
+        <span asp-validation-for="Input.UserName" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Input.Password"></label>
+        <input asp-for="Input.Password" class="form-control" type="password" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="form-group form-check">
+        <input asp-for="Input.RememberMe" class="form-check-input" />
+        <label asp-for="Input.RememberMe" class="form-check-label"></label>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/TestCodex/Pages/Account/Login.cshtml.cs
+++ b/TestCodex/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TestCodex.Pages.Account;
+
+public class LoginModel : PageModel
+{
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public string? ReturnUrl { get; set; }
+
+    public void OnGet(string? returnUrl = null)
+    {
+        ReturnUrl = returnUrl ?? Url.Content("~/");
+    }
+
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+    {
+        ReturnUrl = returnUrl ?? Url.Content("~/");
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        // In a real application, validate user credentials from a user store.
+        if (Input.UserName == "admin" && Input.Password == "admin")
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Name, Input.UserName)
+            };
+
+            var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+
+            await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme,
+                new ClaimsPrincipal(claimsIdentity));
+
+            return LocalRedirect(ReturnUrl);
+        }
+
+        ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+        return Page();
+    }
+
+    public class InputModel
+    {
+        [Required]
+        public string UserName { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        [Display(Name = "Remember me")]
+        public bool RememberMe { get; set; }
+    }
+}
+

--- a/TestCodex/Program.cs
+++ b/TestCodex/Program.cs
@@ -1,7 +1,15 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorPages();
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/Account/Login";
+    });
 
 var app = builder.Build();
 
@@ -16,8 +24,8 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseRouting();
-
-app.UseAuthorization();
+  app.UseAuthentication();
+  app.UseAuthorization();
 
 app.MapStaticAssets();
 app.MapRazorPages()


### PR DESCRIPTION
## Summary
- add Razor login page under Account using a simple ABP-like form
- configure cookie authentication and login path in Program

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9544d32d4832ea74a48ce2e1eda1c